### PR TITLE
Adds entry file directory as module directory

### DIFF
--- a/src/webpack/config-builder.js
+++ b/src/webpack/config-builder.js
@@ -24,6 +24,13 @@ export default function webpackConfigBuilder(filename: string, flags: CLIFlags, 
       preLoaders: preloaders(),
       loaders: loaders(flags, params)
     },
+    resolve: {
+      modulesDirectories: [
+        path.dirname(path.resolve(process.cwd(), filename)),
+        'web_modules',
+        'node_modules'
+      ]
+    },
     eslint: {
       configFile: path.join(__dirname, '../eslint-config.js'),
       useEslintrc: false


### PR DESCRIPTION
Closes #118

Tells webpack to search in the entry file directory for modules, along with the default webpack modulesDirectories. 

We can discuss which directory should be searched for first but my rationale is that the type of folders I will have in my base dir, such as "models", "reducers", "styles", "components", etc. will generally not conflict with packages I have installed. In the event that they do conflict, it is easier for me to resolve the conflict by renaming my folders than it is to alias an npm package.

Finally, I ran this change against the aik-examples and this does not cause an issue on my system.